### PR TITLE
fix AttributeError: 'NoneType' object has no attribute 'startswith'

### DIFF
--- a/scripts/tool.py
+++ b/scripts/tool.py
@@ -124,6 +124,6 @@ temp_path = get_temp_path()
 def get_locale():
     import locale
     lang, _ = locale.getdefaultlocale()
-    return 'zh' if lang.startswith('zh') else 'en'
+    return 'zh' if lang and lang.startswith('zh') else 'en'
 
 locale = get_locale()


### PR DESCRIPTION
`getdefaultlocale()` returns `(None, 'UTF-8')` for me, so extension crashes on startup.