### PR TITLE
sendToControlNet - german

### DIFF
--- a/vue/src/i18n.ts
+++ b/vue/src/i18n.ts
@@ -237,7 +237,6 @@ const en: Record<keyof typeof zh, string> = {
   sendToImg2img: 'Send to img2img',
   sendToInpaint: 'Send to Inpaint',
   sendToExtraFeatures: 'Send to Extra',
-  //! MissingTranslations
   sendToControlNet: 'Send to ControlNet',
   loadNextPage: 'Load next page',
   autoUpload: 'Auto upload',
@@ -373,6 +372,7 @@ const de: Partial<Record<keyof typeof zh, string>> = {
   sendToImg2img: "Senden an Bild-zu-Bild",
   sendToInpaint: "Senden an Inpaint",
   sendToExtraFeatures: "Senden an Extras",
+  sendToControlNet: 'Senden an ControlNet',
   loadNextPage: "Nächste Seite laden",
   autoUpload: "Automatisches Hochladen",
   localFile: "Lokale Datei",


### PR DESCRIPTION
Haha, I was thinking that you could include it in the German translation like this because you never know when someone might create translations in other languages like Portuguese, Spanish, French, etc. This way, each translation can be done at their own speed, and translators can easily see which translations they might have missed. ^^'

inside other translation's:
//! sendToControlNet: 'Send to ControlNet',