### PR TITLE
Add functionality to customize host

### DIFF
--- a/app.py
+++ b/app.py
@@ -148,6 +148,9 @@ def setup_parser() -> argparse.ArgumentParser:
         description="A fast and powerful image browser for Stable Diffusion webui."
     )
     parser.add_argument(
+        "--host", type=str, default="127.0.0.1", help="The host to use"
+    )
+    parser.add_argument(
         "--port", type=int, help="The port to use", default=default_port
     )
     parser.add_argument(
@@ -186,7 +189,7 @@ def setup_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def launch_app(port: int = default_port, *args, **kwargs: dict) -> None:
+def launch_app(host: str = default_host, port: int = default_port, *args, **kwargs: dict) -> None:
     """
     Launches the application on the specified port.
 
@@ -196,10 +199,10 @@ def launch_app(port: int = default_port, *args, **kwargs: dict) -> None:
     """
     app_utils = AppUtils(*args, **kwargs)
     app = app_utils.get_root_browser_app()
-    uvicorn.run(app, host=default_host, port=port)
+    uvicorn.run(app, host=host, port=port)
 
 
-async def async_launch_app(port: int = default_port, *args, **kwargs: dict) -> None:
+async def async_launch_app(host: str = default_host, port: int = default_port, *args, **kwargs: dict) -> None:
     """
     Asynchronously launches the application on the specified port.
 
@@ -209,7 +212,7 @@ async def async_launch_app(port: int = default_port, *args, **kwargs: dict) -> N
     """
     app_utils = AppUtils(*args, **kwargs)
     app = app_utils.get_root_browser_app()
-    await app_utils.async_run(app, port=port)
+    await app_utils.async_run(app, host=host, port=port)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Dear Project Maintainers,

Firstly, I would like to express my sincere appreciation for your hard work on this valuable project. I have been using it extensively and it has significantly boosted my productivity.

Recently, while using the application, I noticed that it currently only allows running on localhost (127.0.0.1). Although this works well for local development and testing, it can be limiting in scenarios where the application needs to be accessed from different network locations.

In light of this, I have made an enhancement to the project by introducing a feature that allows users to specify a custom host when launching the application. Users can now set the host using the --host command line option. Please note that if a host is not specified, the application will default to localhost (127.0.0.1).

The changes are contained in the attached commits and include modifications to the setup_parser(), launch_app(), and async_launch_app() functions. The commits are self-contained and do not affect any other functionalities of the project.

I believe that this enhancement will not only benefit me, but also other users who might face a similar need. I hope you will consider this addition favourably. If any further modifications or discussions are required, please let me know.

Thank you again for your commendable work on this project and I look forward to your response.