### PR TITLE
added compatibility with several comfyUI workflows

### DIFF
--- a/scripts/iib/tool.py
+++ b/scripts/iib/tool.py
@@ -394,7 +394,8 @@ def get_img_geninfo_txt_path(path: str):
         return txt_path
 
 def is_img_created_by_comfyui(img: Image):
-    return img.info.get('prompt') #and img.info.get('workflow') # ermanitu
+    prompt = img.info.get('prompt')
+    return prompt and (img.info.get('workflow') or ("class_type" in prompt)) # ermanitu
 
 def is_img_created_by_comfyui_with_webui_gen_info(img: Image):
     return is_img_created_by_comfyui(img) and img.info.get('parameters')
@@ -419,7 +420,7 @@ def get_comfyui_exif_data(img: Image):
 
     # As a workaround to bypass parsing errors in the parser.
     # https://github.com/jiw0220/stable-diffusion-image-metadata/blob/00b8d42d4d1a536862bba0b07c332bdebb2a0ce5/src/index.ts#L130
-    meta["Steps"] = KSampler_entry["steps"]
+    meta["Steps"] = KSampler_entry.get("steps", "Unknown")
     meta["Sampler"] = KSampler_entry["sampler_name"]
     meta["Model"] = data[KSampler_entry["model"][0]]["inputs"].get("ckpt_name") # ermanitu
     meta["Source Identifier"] = "ComfyUI"

--- a/scripts/iib/tool.py
+++ b/scripts/iib/tool.py
@@ -394,7 +394,7 @@ def get_img_geninfo_txt_path(path: str):
         return txt_path
 
 def is_img_created_by_comfyui(img: Image):
-    return img.info.get('prompt') and img.info.get('workflow')
+    return img.info.get('prompt') #and img.info.get('workflow') # ermanitu
 
 def is_img_created_by_comfyui_with_webui_gen_info(img: Image):
     return is_img_created_by_comfyui(img) and img.info.get('parameters')
@@ -415,11 +415,13 @@ def get_comfyui_exif_data(img: Image):
             pass
     meta = {}
     KSampler_entry = data[meta_key]["inputs"]
+    print(KSampler_entry)
+
     # As a workaround to bypass parsing errors in the parser.
     # https://github.com/jiw0220/stable-diffusion-image-metadata/blob/00b8d42d4d1a536862bba0b07c332bdebb2a0ce5/src/index.ts#L130
-    meta["Steps"] = "Unknown" 
+    meta["Steps"] = KSampler_entry["steps"]
     meta["Sampler"] = KSampler_entry["sampler_name"]
-    meta["Model"] = data[KSampler_entry["model"][0]]["inputs"]["ckpt_name"]
+    meta["Model"] = data[KSampler_entry["model"][0]]["inputs"].get("ckpt_name") # ermanitu
     meta["Source Identifier"] = "ComfyUI"
     def get_text_from_clip(idx: str) :
         inputs = data[idx]["inputs"]
@@ -427,7 +429,14 @@ def get_comfyui_exif_data(img: Image):
         if isinstance(text, list): # type:CLIPTextEncode (NSP) mode:Wildcards
             text = data[text[0]]["inputs"]["text"]
         return text.strip()
-    pos_prompt = get_text_from_clip(KSampler_entry["positive"][0])
+    
+    # added by ermanitu
+    in_node = data[str(KSampler_entry["positive"][0])]
+    if in_node["class_type"] != "FluxGuidance":
+        pos_prompt = get_text_from_clip(KSampler_entry["positive"][0])
+    else:
+        pos_prompt = get_text_from_clip(in_node["inputs"]["conditioning"][0])
+
     neg_prompt = get_text_from_clip(KSampler_entry["negative"][0])
     pos_prompt_arr = unique_by(parse_prompt(pos_prompt)["pos_prompt"])
     return {


### PR DESCRIPTION
**First improvement:**

The input to a KSampler model is not always from a LoadCheckPoint node, as it can be mediated by a LoadLora or similar. In these cases, IIB was failing and not continuing the execution of the function.

Note that in python "get" doesn't cause error if the key doesn't exists. Instead of this, it returns None. This not get properly the model used, but at least get the rest of the params.

**Second improvement:**

The code assumes the "positive" input of KSampler is the positive prompt, but may not be the case. Some flux.1 workflows have a node "Guidance" between the positive prompt and the KSampler.

If there is a FluxGuidance node then give an step back to get the prompt.

Images to test:

![383215349-3f0c0128-e8ab-4c55-93f6-fb51c6a9eae3](https://github.com/user-attachments/assets/94099f3e-0084-4f68-a1a1-54a38a10c8e8)

![ComfyUI_temp_sunbk_00002_](https://github.com/user-attachments/assets/f1f8bec3-7e77-43eb-9a01-c8b538fc6a56)


