### PR TITLE
fix: Lock major versions for requests, numpy, hnswlib and add runtime…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ imageio
 av>=14,<15
 lxml
 filetype
-requests
-numpy
-hnswlib
+requests>=2.0.0,<3.0.0
+numpy>=2.0.0,<3.0.0
+hnswlib>=0.0.0,<1.0.0

--- a/scripts/iib/api.py
+++ b/scripts/iib/api.py
@@ -381,6 +381,9 @@ def infinite_image_browsing_api(app: FastAPI, **kwargs):
             "pillow": _get_dist_version("Pillow", "PIL"),
             "imageio_ffmpeg": _get_dist_version("imageio-ffmpeg", "imageio_ffmpeg"),
             "pillow_avif_plugin": _get_dist_version("pillow-avif-plugin", "pillow_avif"),
+            "requests": _get_dist_version("requests", "requests"),
+            "numpy": _get_dist_version("numpy", "numpy"),
+            "hnswlib": _get_dist_version("hnswlib", "hnswlib"),
         }
 
         logger.info("Version info requested: %s", {k: v for k, v in versions.items() if v})


### PR DESCRIPTION
… version info

- Lock requests to >=2.0.0,<3.0.0 (current: 2.32.5)
- Lock numpy to >=2.0.0,<3.0.0 (current: 2.4.0)
- Lock hnswlib to >=0.0.0,<1.0.0 (current: 0.8.0)
- Add runtime version info for requests, numpy, hnswlib in /version endpoint