### PR TITLE
fix: Set numpy version requirement to >=1.10.0 and add runtime versio…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ av>=14,<15
 lxml
 filetype
 requests>=2.0.0,<3.0.0
-numpy>=2.0.0,<3.0.0
+numpy>=1.10.0,<3.0.0
 hnswlib>=0.0.0,<1.0.0


### PR DESCRIPTION
…n info

- Set numpy to >=1.10.0,<3.0.0 (minimum for np.stack function, compatible with Python 3.11 and below)
- Python 3.12 users will automatically get numpy 1.26.0+ due to compatibility
- Add runtime version info for requests, numpy, hnswlib in /version endpoint