### PR TITLE
fix sh command failing from syntax error.

### DIFF
--- a/install.py
+++ b/install.py
@@ -20,9 +20,9 @@ with open(req_file) as file:
                 package_name, package_version = package.split('==')
                 installed_version = pkg_resources.get_distribution(package_name).version
                 if installed_version != package_version:
-                    launch.run_pip(f"install {package}", f"sd-webui-infinite-image-browsing requirement: changing {package_name} version from {installed_version} to {package_version}")
+                    launch.run_pip(f"install '{package}'", f"sd-webui-infinite-image-browsing requirement: changing {package_name} version from {installed_version} to {package_version}")
             elif not launch.is_installed(dist2package(package)):
-                launch.run_pip(f"install {package}", f"sd-webui-infinite-image-browsing requirement: {package}")
+                launch.run_pip(f"install '{package}'", f"sd-webui-infinite-image-browsing requirement: {package}")
         except Exception as e:
             print(e)
             print(f'Warning: Failed to install {package}, something may not work.')


### PR DESCRIPTION
the failure in question:
Python 3.10.7 (main, Oct  3 2022, 02:19:58) [Clang 14.0.3 ] Version: f2.0.1v1.10.1-previous-669-gdfdcbab6
Commit hash: dfdcbab685e57677014f05a3309b48cc87383167 Installing requirements
Installing sd-webui-infinite-image-browsing requirement: av>=14,<15 Couldn't install sd-webui-infinite-image-browsing requirement: av>=14,<15. Command: "/home/silve/stable-diffusion-webui-forge/venv/bin/python" -m pip install av>=14,<15 --prefer-binary Error code: 1
stderr: /bin/sh: line 1: 15: No such file or directory

Warning: Failed to install av>=14,<15, something may not work.
Installing sd-webui-infinite-image-browsing requirement: requests>=2.0.0,<3.0.0
Couldn't install sd-webui-infinite-image-browsing requirement: requests>=2.0.0,<3.0.0.
Command: "/home/silve/stable-diffusion-webui-forge/venv/bin/python" -m pip install requests>=2.0.0,<3.0.0 --prefer-binary
Error code: 1
stderr: /bin/sh: line 1: 3.0.0: No such file or directory

Warning: Failed to install requests>=2.0.0,<3.0.0, something may not work.
Installing sd-webui-infinite-image-browsing requirement: numpy>=2.0.0,<3.0.0
Couldn't install sd-webui-infinite-image-browsing requirement: numpy>=2.0.0,<3.0.0.
Command: "/home/silve/stable-diffusion-webui-forge/venv/bin/python" -m pip install numpy>=2.0.0,<3.0.0 --prefer-binary
Error code: 1
stderr: /bin/sh: line 1: 3.0.0: No such file or directory

Warning: Failed to install numpy>=2.0.0,<3.0.0, something may not work.
Installing sd-webui-infinite-image-browsing requirement: hnswlib>=0.0.0,<1.0.0
Couldn't install sd-webui-infinite-image-browsing requirement: hnswlib>=0.0.0,<1.0.0.
Command: "/home/silve/stable-diffusion-webui-forge/venv/bin/python" -m pip install hnswlib>=0.0.0,<1.0.0 --prefer-binary
Error code: 1
stderr: /bin/sh: line 1: 1.0.0: No such file or directory

Could not test the change bc my sd-webui forge is borken rn. I can if you want test after I finish fixing my webui