### PR TITLE
fix: add null checks for Tag.get_or_create calls

### DIFF
--- a/scripts/iib/api.py
+++ b/scripts/iib/api.py
@@ -1178,6 +1178,8 @@ def infinite_image_browsing_api(app: FastAPI, **kwargs):
         conn = DataBase.get_conn()
         tag = Tag.get_or_create(conn, name=req.tag_name, type="custom")
         conn.commit()
+        if tag is None:
+            raise HTTPException(400, "Invalid tag name")
         return tag
     
     class RenameFileReq(BaseModel):

--- a/scripts/iib/auto_tag.py
+++ b/scripts/iib/auto_tag.py
@@ -96,6 +96,7 @@ class AutoTagMatcher:
                     tag_name = rule.get("tag")
                     if tag_name:
                         tag = Tag.get_or_create(self.conn, tag_name, "custom")
-                        ImageTag(img_id, tag.id).save_or_ignore(self.conn)
+                        if tag:
+                            ImageTag(img_id, tag.id).save_or_ignore(self.conn)
             except Exception as e:
                 logger.error(f"Error applying auto tag rule {rule}: {e}")

--- a/scripts/iib/db/datamodel.py
+++ b/scripts/iib/db/datamodel.py
@@ -720,9 +720,9 @@ class Tag:
             if len(name) > 12:
                 return "INVALID_TAG_NAME_TOO_LONG"
         else:
-            # Other languages: max 6 words
+            # Other languages: max 8 words and 40 characters
             words = name.split()
-            if len(words) > 6:
+            if len(words) > 8 and len(name) > 40:
                 return "INVALID_TAG_TOO_MANY_WORDS"
         
         return None
@@ -798,8 +798,8 @@ class Tag:
         # Validate tag name
         error_name = cls.validate_tag_name(name)
         if error_name:
-            # Use get_or_create recursively to ensure error tag has an id
-            return cls.get_or_create(conn, error_name, "error")
+            # Return None for invalid tag names
+            return None
         
         with closing(conn.cursor()) as cur:
             cur.execute(

--- a/scripts/iib/db/update_image_data.py
+++ b/scripts/iib/db/update_image_data.py
@@ -189,7 +189,8 @@ def build_single_img_idx(conn, file_path, is_rebuild, safe_save_img_tag):
         size_str,
         type="size",
     )
-    safe_save_img_tag(ImageTag(img.id, size_tag.id))
+    if size_tag:
+        safe_save_img_tag(ImageTag(img.id, size_tag.id))
     # 确定媒体类型：Image / Video / Audio / Unknown
     if is_image_file(file_path):
         media_type_name = "Image"
@@ -200,7 +201,8 @@ def build_single_img_idx(conn, file_path, is_rebuild, safe_save_img_tag):
     else:
         media_type_name = "Unknown"
     media_type_tag = Tag.get_or_create(conn, media_type_name, 'Media Type')
-    safe_save_img_tag(ImageTag(img.id, media_type_tag.id))
+    if media_type_tag:
+        safe_save_img_tag(ImageTag(img.id, media_type_tag.id))
     keys = [
         "Model",
         "Sampler",
@@ -218,21 +220,27 @@ def build_single_img_idx(conn, file_path, is_rebuild, safe_save_img_tag):
             continue
         
         tag = Tag.get_or_create(conn, str(v), k)
-        safe_save_img_tag(ImageTag(img.id, tag.id))
-        if "Hires upscaler" == k:
-            tag = Tag.get_or_create(conn, 'Hires All', k)
+        if tag:
             safe_save_img_tag(ImageTag(img.id, tag.id))
-        elif "Refiner" == k:
-            tag = Tag.get_or_create(conn, 'Refiner All', k)
-            safe_save_img_tag(ImageTag(img.id, tag.id))
+            if "Hires upscaler" == k:
+                tag = Tag.get_or_create(conn, 'Hires All', k)
+                if tag:
+                    safe_save_img_tag(ImageTag(img.id, tag.id))
+            elif "Refiner" == k:
+                tag = Tag.get_or_create(conn, 'Refiner All', k)
+                if tag:
+                    safe_save_img_tag(ImageTag(img.id, tag.id))
     for i in lora:
         tag = Tag.get_or_create(conn, i["name"], "lora")
-        safe_save_img_tag(ImageTag(img.id, tag.id))
+        if tag:
+            safe_save_img_tag(ImageTag(img.id, tag.id))
     for i in lyco:
         tag = Tag.get_or_create(conn, i["name"], "lyco")
-        safe_save_img_tag(ImageTag(img.id, tag.id))
+        if tag:
+            safe_save_img_tag(ImageTag(img.id, tag.id))
     for k in pos:
         tag = Tag.get_or_create(conn, k, "pos")
-        safe_save_img_tag(ImageTag(img.id, tag.id))
+        if tag:
+            safe_save_img_tag(ImageTag(img.id, tag.id))
     
     AutoTagMatcher.get_instance(conn).apply(img.id, parsed_params)


### PR DESCRIPTION
- Tag.get_or_create now returns None for invalid tag names instead of creating error tags
- Add null checks before using tag.id in all callers
- Adjust tag validation: non-Chinese tags now limited to 8 words or 40 characters