### PR TITLE
Possible bug fix for "Open with default app" on Windows

### DIFF
--- a/scripts/iib/tool.py
+++ b/scripts/iib/tool.py
@@ -993,7 +993,7 @@ def open_file_with_default_app(file_path):
     if system == 'Darwin':  # macOS
         subprocess.call(['open', file_path])
     elif system == 'Windows':  # Windows
-        subprocess.call(file_path, shell=True)
+        os.startfile(file_path)
     elif system == 'Linux':  # Linux
         subprocess.call(['xdg-open', file_path])
     else:


### PR DESCRIPTION
Working with the IIB extension in Forge WebUI locally on my Windows PC, I noticed a problem when using "Open with default app". Initially it works as expected: The Windows default Photo Viewer opens and lets me work with the image. However when I open another image, it is no longer possible to edit the image and trying to do so will result in error messages. Fortunately, the error does not persist and opening the file manually works fine.

I found that replacing the subprocess call with os.startfile gets rid of this behavior and everything seems to works as expected. I did not test whether the problem occurs with other default image viewers as well, but I still wanted to propose this solution.