### PR TITLE
Fix ImportError: cannot import name 'generation_parameters_copypaste'

### DIFF
--- a/scripts/iib_setup.py
+++ b/scripts/iib_setup.py
@@ -1,5 +1,5 @@
 from scripts.iib.api import infinite_image_browsing_api, send_img_path
-from modules import script_callbacks, generation_parameters_copypaste as send
+from modules import script_callbacks, infotext_utils as send
 from scripts.iib.tool import locale
 from scripts.iib.tool import read_sd_webui_gen_info_from_image
 from PIL import Image


### PR DESCRIPTION
A popular fork of SD Forge,  [Neo](https://github.com/Haoming02/sd-webui-forge-classic/tree/neo), removed the compatibility alias that mapped `modules.generation_parameters_copypaste` to `modules.infotext_utils` (the module it was renamed to some time ago).

This caused IIB to fail on load with an ImportError.

This PR updates the import in `scripts/iib_setup.py` to use `infotext_utils` directly, which works across all current versions of A1111, Forge, and Forge neo.