### PR TITLE
fix(setup): import infotext_utils instead of removed legacy alias

### DIFF
--- a/scripts/iib_setup.py
+++ b/scripts/iib_setup.py
@@ -1,5 +1,5 @@
 from scripts.iib.api import infinite_image_browsing_api, send_img_path
-from modules import script_callbacks, generation_parameters_copypaste as send
+from modules import script_callbacks, infotext_utils as send
 from scripts.iib.tool import locale
 from scripts.iib.tool import read_sd_webui_gen_info_from_image
 from PIL import Image


### PR DESCRIPTION
## Summary

`scripts/iib_setup.py` imports the renamed-and-now-removed
`modules.generation_parameters_copypaste` alias, which causes the
extension to fail at script load on current **Stable Diffusion WebUI
Forge Classic** — the IIB tab silently disappears from the UI.

## Background

- `modules.generation_parameters_copypaste` was renamed to
  `modules.infotext_utils` in A1111 in
  [003b91f0](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/003b91f0)
  (2024-01-01). A `sys.modules["modules.generation_parameters_copypaste"] = …`
  alias was added in `modules/infotext_utils.py` for back-compat.
- Forge Classic dropped that alias in commit
  [`e40900cd`](https://github.com/Haoming02/sd-webui-forge-classic/commit/e40900cd)
  on 2026-05-05 ("yeet — 1.8.0 was 2 years ago").
- After that change, `from modules import … generation_parameters_copypaste as send`
  raises `ImportError: cannot import name 'generation_parameters_copypaste' from 'modules' (unknown location)`,
  so neither `on_ui_tabs` nor `on_app_started` get registered, and IIB
  becomes invisible to the user.

## Fix

Single-line change in `scripts/iib_setup.py`:

```diff
-from modules import script_callbacks, generation_parameters_copypaste as send
+from modules import script_callbacks, infotext_utils as send
```

`infotext_utils` exposes the same `ParamBinding` and
`register_paste_params_button` symbols used a few lines below. On
A1111 and older Forge releases the legacy alias still resolves to the
same module, so this is a strict superset of the previous behaviour:
it works on every WebUI variant that has `infotext_utils` (which is
all of them since 2024), and on no variant does it regress.

## Test plan

- [x] Reproduced the silent tab-missing behaviour on Forge Classic
      `cd2490a8` (2026-05-07).
- [x] Verified that `from modules import infotext_utils` succeeds in
      Forge Classic's runtime.
- [x] Verified `infotext_utils.ParamBinding` and
      `infotext_utils.register_paste_params_button` exist.
- [ ] Reviewer to confirm no regression on stock A1111 / older Forge
      (the alias was a thin re-export; this change just skips the
      indirection).