### PR TITLE
fix(setup): Add existence check for register_paste_params_button attribute

### DIFF
--- a/scripts/iib_setup.py
+++ b/scripts/iib_setup.py
@@ -51,16 +51,17 @@ def on_ui_tabs():
                 img_file_info = gr.Textbox(elem_id="iib_hidden_img_file_info")
                 img_update_trigger.click(img_update_func, outputs=[img, img_file_info])
                 for tab in ["txt2img", "img2img", "inpaint", "extras"]:
-                    btn = gr.Button(f"Send to {tab}", elem_id=f"iib_hidden_tab_{tab}")
-                    # 注册粘贴
-                    send.register_paste_params_button(
-                        send.ParamBinding(
-                            paste_button=btn,
-                            tabname=tab,
-                            source_image_component=img,
-                            source_text_component=img_file_info,
+                    if hasattr(send, 'register_paste_params_button'):
+                        btn = gr.Button(f"Send to {tab}", elem_id=f"iib_hidden_tab_{tab}")
+                        # 注册粘贴
+                        send.register_paste_params_button(
+                            send.ParamBinding(
+                                paste_button=btn,
+                                tabname=tab,
+                                source_image_component=img,
+                                source_text_component=img_file_info,
+                            )
                         )
-                    )
 
         return (
             (


### PR DESCRIPTION
I added check if UI have `register_paste_params_button` attribute because ModernUI which SD.Next uses, doesn't have it.

Error that apear when UI don't have this attribute:
```python
Executing callback: X:\sdnext\extensions\infinite-image-browsing\scripts\iib_setup.py
                         ui_tabs_callback: AttributeError
X:\sdnext\modules\script_callbacks.py:218 in ui_tabs_callback

  217             t0 = time.time()
❱ 218             res += c.callback() or []
  219             timer(t0, c.script, 'ui_tabs')

X:\sdnext\extensions\infinite-image-browsing\scripts\iib_setup.py:56 in on_ui_tabs

  55                     # 注册粘贴
❱ 56                     send.register_paste_params_button(
  57                         send.ParamBinding(
AttributeError: module 'modules.infotext_utils' has no attribute 'register_paste_params_button'
```