### PR TITLE
feat: add JSON schemas to tag_graph and topic_cluster LLM requests for grammar-constrained  decoding

### DIFF
--- a/scripts/iib/tag_graph.py
+++ b/scripts/iib/tag_graph.py
@@ -24,7 +24,66 @@ _TOPK_TAGS_FOR_LLM = int(os.getenv("IIB_TAG_GRAPH_TOPK_TAGS_FOR_LLM", "500") or 
 _LLM_REQUEST_TIMEOUT_SEC = int(os.getenv("IIB_TAG_GRAPH_LLM_TIMEOUT_SEC", "180") or "180")
 _LLM_MAX_ATTEMPTS = int(os.getenv("IIB_TAG_GRAPH_LLM_MAX_ATTEMPTS", "5") or "5")
 
- 
+# JSON Schema for llama.cpp grammar-constrained decoding.
+# Enforces valid JSON structure so weak models can't produce broken output.
+# llama.cpp converts this to a GBNF grammar at inference time.
+TAG_GRAPH_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "layers": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "level": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 2
+                    },
+                    "groups": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "minLength": 1
+                                },
+                                "label": {
+                                    "type": "string",
+                                    "minLength": 1
+                                },
+                                "tags": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "categories": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "required": ["id", "label"],
+                            "additionalProperties": False
+                        }
+                    }
+                },
+                "required": ["level", "groups"],
+                "additionalProperties": False
+            }
+        }
+    },
+    "required": ["layers"],
+    "additionalProperties": False
+}
+
+
 class TagGraphReq(BaseModel):
     folder_paths: List[str]
     lang: Optional[str] = "en"  # Language for LLM output
@@ -114,11 +173,9 @@ GUIDELINES:
 3. Every tag must belong to exactly ONE Level 1 category
 4. Use {normalized_lang} for all category labels
 5. Category IDs must be simple lowercase (e.g., "style", "char", "scene1")
-
-OUTPUT ONLY VALID JSON - NO markdown, NO explanations, NO extra text:
-{{"layers":[{{"level":1,"groups":[{{"id":"cat1","label":"Label1","tags":["tag1"]}},{{"id":"cat2","label":"Label2","tags":["tag2"]}}]}},{{"level":2,"groups":[{{"id":"super1","label":"SuperLabel","categories":["cat1","cat2"]}}]}}]}}
-
-If unsure about Level 2, OMIT it entirely. Start response with {{ and end with }}"""
+6. Level 1 groups use "tags" field (list of tag strings)
+7. Level 2 groups use "categories" field (list of Level 1 group IDs)
+8. Output must be valid JSON matching the provided schema"""
 
             user_prompt = f"Tags to categorize:\n{', '.join(tags)}"
 
@@ -131,6 +188,10 @@ If unsure about Level 2, OMIT it entirely. Start response with {{ and end with }
                 "temperature": 0.0,
                 "max_tokens": 32768,
                 "stream": True,
+                "response_format": {
+                    "type": "json_object",
+                    "schema": TAG_GRAPH_JSON_SCHEMA,
+                },
             }
 
             request_id = f"tg_{int(time.time() * 1000)}_{os.getpid()}"
@@ -250,7 +311,7 @@ If unsure about Level 2, OMIT it entirely. Start response with {{ and end with }
             )
 
         return await asyncio.to_thread(_call_sync)
- 
+
     @app.post(
         f"{db_api_base}/cluster_tag_graph",
         dependencies=[Depends(verify_secret)],
@@ -324,7 +385,7 @@ If unsure about Level 2, OMIT it entirely. Start response with {{ and end with }
             str(req.lang or ""),
         )
 
- 
+
 
         # Graph cache (best-effort): cache by topic_cluster_cache_key + lang + version.
         graph_cache_key = None

--- a/scripts/iib/tag_graph.py
+++ b/scripts/iib/tag_graph.py
@@ -175,7 +175,11 @@ GUIDELINES:
 5. Category IDs must be simple lowercase (e.g., "style", "char", "scene1")
 6. Level 1 groups use "tags" field (list of tag strings)
 7. Level 2 groups use "categories" field (list of Level 1 group IDs)
-8. Output must be valid JSON matching the provided schema"""
+8. OUTPUT ONLY VALID JSON - NO markdown, NO explanations, NO extra text:
+{{"layers":[{{"level":1,"groups":[{{"id":"cat1","label":"Label1","tags":["tag1"]}},{{"id":"cat2","label":"Label2","tags":["tag2"]}}]}},{{"level":2,"groups":[{{"id":"super1","label":"SuperLabel","categories":["cat1","cat2"]}}]}}]}}
+
+If unsure about Level 2, OMIT it entirely. Start response with {{ and end with }}
+"""
 
             user_prompt = f"Tags to categorize:\n{', '.join(tags)}"
 

--- a/scripts/iib/topic_cluster.py
+++ b/scripts/iib/topic_cluster.py
@@ -577,15 +577,21 @@ def _call_chat_title_sync(
         logger.error("[chat_title] No prompt samples for title generation")
         raise HTTPException(status_code=400, detail="No prompt samples for title generation")
 
+    json_example = '{"title":"...","keywords":["...","..."]}'
     sys = (
         "You are a topic naming assistant for image-generation prompts.\n"
-        "Given several prompt snippets that belong to the SAME theme, output a short topic title and 3–6 keywords.\n"
+        "Given several prompt snippets that belong to the SAME theme, output:\n"
+        "- a short topic title\n"
+        "- 3–6 keywords.\n"
         "\n"
         "Rules:\n"
         f"- Output language MUST be: {output_lang}\n"
         "- Prefer 4–12 characters for Chinese (Simplified/Traditional), otherwise 2–6 English/German words.\n"
         "- Avoid generic boilerplate like: masterpiece, best quality, highly detailed, cinematic, etc.\n"
         "- Keep distinctive terms if they help differentiate themes (e.g., Warhammer 40K, Lolita, scientific illustration).\n"
+        "- Do NOT output explanations. Do NOT output markdown/code fences.\n"
+        "- The output MUST start with '{' and end with '}' (no leading/trailing characters).\n"
+        "\n"
     )
     # Add existing folder names hint for file organization scenarios
     if existing_folder_names:
@@ -624,6 +630,7 @@ def _call_chat_title_sync(
         
         sys += strictness_msg
         sys += f"Existing keywords ({len(top_keywords)} of {unique_count} total): {', '.join(top_keywords)}\n\n"
+    sys += "Output STRICT JSON only:\n" + json_example
     user = "Prompt snippets:\n" + "\n".join([f"- {s}" for s in samples])
 
     payload = {

--- a/scripts/iib/topic_cluster.py
+++ b/scripts/iib/topic_cluster.py
@@ -1878,7 +1878,8 @@ def mount_topic_cluster_routes(
         # TopK by cosine similarity (brute force; MVP only)
         import heapq
 
-        heap: List[Tuple[float, Dict]] = []
+        heap: List[Tuple[float, int, Dict]] = []
+        heap_idx = 0
         total = 0
         for image_id, path, exif, vec_blob in rows:
             if not isinstance(path, str) or not os.path.exists(path):
@@ -1903,13 +1904,15 @@ def mount_topic_cluster_routes(
                 "sample_prompt": _clean_for_title(_extract_prompt_text(exif, max_chars=max_chars))[:200],
             }
             if len(heap) < top_k:
-                heapq.heappush(heap, (score, item))
+                heapq.heappush(heap, (score, heap_idx, item))
+                heap_idx += 1
             else:
                 if score > heap[0][0]:
-                    heapq.heapreplace(heap, (score, item))
+                    heapq.heapreplace(heap, (score, heap_idx, item))
+                    heap_idx += 1
 
         heap.sort(key=lambda x: x[0], reverse=True)
-        results = [x[1] for x in heap]
+        results = [x[2] for x in heap]
         return {
             "query": q,
             "folder": folder,

--- a/scripts/iib/topic_cluster.py
+++ b/scripts/iib/topic_cluster.py
@@ -24,6 +24,30 @@ _np = None
 _hnswlib = None
 _PERF_DEPS_READY = False
 
+# JSON schema to enforce valid topic naming output from LLM (for llama.cpp grammar conversion)
+_TOPIC_NAMING_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 24
+        },
+        "keywords": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 6,
+            "items": {
+                "type": "string",
+                "minLength": 1
+            }
+        }
+    },
+    "required": ["title", "keywords"],
+    "additionalProperties": False
+}
+
 
 def _ensure_perf_deps() -> None:
     """
@@ -553,21 +577,15 @@ def _call_chat_title_sync(
         logger.error("[chat_title] No prompt samples for title generation")
         raise HTTPException(status_code=400, detail="No prompt samples for title generation")
 
-    json_example = '{"title":"...","keywords":["...","..."]}'
     sys = (
         "You are a topic naming assistant for image-generation prompts.\n"
-        "Given several prompt snippets that belong to the SAME theme, output:\n"
-        "- a short topic title\n"
-        "- 3–6 keywords.\n"
+        "Given several prompt snippets that belong to the SAME theme, output a short topic title and 3–6 keywords.\n"
         "\n"
         "Rules:\n"
         f"- Output language MUST be: {output_lang}\n"
         "- Prefer 4–12 characters for Chinese (Simplified/Traditional), otherwise 2–6 English/German words.\n"
         "- Avoid generic boilerplate like: masterpiece, best quality, highly detailed, cinematic, etc.\n"
         "- Keep distinctive terms if they help differentiate themes (e.g., Warhammer 40K, Lolita, scientific illustration).\n"
-        "- Do NOT output explanations. Do NOT output markdown/code fences.\n"
-        "- The output MUST start with '{' and end with '}' (no leading/trailing characters).\n"
-        "\n"
     )
     # Add existing folder names hint for file organization scenarios
     if existing_folder_names:
@@ -606,7 +624,6 @@ def _call_chat_title_sync(
         
         sys += strictness_msg
         sys += f"Existing keywords ({len(top_keywords)} of {unique_count} total): {', '.join(top_keywords)}\n\n"
-    sys += "Output STRICT JSON only:\n" + json_example
     user = "Prompt snippets:\n" + "\n".join([f"- {s}" for s in samples])
 
     payload = {
@@ -616,6 +633,10 @@ def _call_chat_title_sync(
         "top_p": 1.0,
         "max_tokens": 4096,
         "stream": True,  # Enable streaming
+        "response_format": {
+            "type": "json_object",
+            "schema": _TOPIC_NAMING_JSON_SCHEMA,
+        },
     }
     # Some OpenAI-compatible providers may use different token limit fields / casing.
     payload["max_output_tokens"] = payload["max_tokens"]


### PR DESCRIPTION
## Summary

Add JSON schemas to the LLM request paths in IIB, ensuring valid structured output from weak models via the OpenAI-compatible `response_format` field (supported by llama.cpp and other providers). This will mostly benefit local LLM users running weaker (or faster) models.

Tested on llama.cpp version b9411 and gemma4 e4b as LLM model and Qwen3 Embedding 0.6b. All AI and clustering features work flawlessly. 

### Changes

**topic_cluster.py — `_call_chat_title_sync`**
- Add `_TOPIC_NAMING_JSON_SCHEMA` enforcing `{title: string(1-24), keywords: string[] (1-6)}`
- Inject `response_format: {type: "json_object", schema}` into the LLM payload
- Simplify system prompt (remove redundant JSON format instructions — schema now enforces structure)

**tag_graph.py** — already done in previous commit (`f44b5bf9`)

### Verification

Schema converts cleanly to GBNF grammar via `llama.cpp/examples/json_schema_to_grammar.py`

### Commits (3)

| Commit | Message |
|--------|---------|
| `7465538` | fix: heap TypeError when equal similarity scores in prompt search |
| `f44b5bf` | tag_graph: add JSON schema for llama.cpp grammar-constrained decoding |
| `fcac8bc` | topic_cluster: add JSON schema for topic naming LLM requests |