### PR TITLE
feat(embeddings): optional TwelveLabs Marengo embedding backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,8 +68,13 @@ OPENAI_BASE_URL=
 OPENAI_API_KEY=
 
 # Embedding model id (OpenAI-compatible).
-# - Used for clustering images by prompt semantics.
+# - Used for clustering images by prompt semantics and for semantic search.
 # - Recommended: start with a small/cheap embedding model; switch to a larger one only if clustering quality is insufficient.
+# - Optional TwelveLabs Marengo backend: set this to "marengo3.0" to embed prompt
+#   text with TwelveLabs Marengo instead of an OpenAI-compatible endpoint. When a
+#   Marengo model is set, OPENAI_API_KEY is used as the TwelveLabs API key and
+#   OPENAI_BASE_URL is ignored. Requires: pip install 'twelvelabs>=1.2.8'.
+#   Free API key (generous free tier): https://twelvelabs.io
 EMBEDDING_MODEL=text-embedding-3-small
 
 # Default chat model id (OpenAI-compatible).

--- a/.env.example
+++ b/.env.example
@@ -72,10 +72,18 @@ OPENAI_API_KEY=
 # - Recommended: start with a small/cheap embedding model; switch to a larger one only if clustering quality is insufficient.
 # - Optional TwelveLabs Marengo backend: set this to "marengo3.0" to embed prompt
 #   text with TwelveLabs Marengo instead of an OpenAI-compatible endpoint. When a
-#   Marengo model is set, OPENAI_API_KEY is used as the TwelveLabs API key and
-#   OPENAI_BASE_URL is ignored. Requires: pip install 'twelvelabs>=1.2.8'.
+#   Marengo model is set, embeddings use TWELVELABS_API_KEY (see below) and
+#   OPENAI_BASE_URL is ignored for embeddings (the OpenAI-compatible chat path used
+#   for cluster titles is unaffected). Requires: pip install 'twelvelabs>=1.2.8'.
 #   Free API key (generous free tier): https://twelvelabs.io
 EMBEDDING_MODEL=text-embedding-3-small
+
+# TwelveLabs API key, used only by the optional Marengo embedding backend
+# (EMBEDDING_MODEL=marengo3.0). Kept separate from OPENAI_API_KEY so the
+# OpenAI-compatible chat path (cluster titles) keeps working independently.
+# If unset, it falls back to OPENAI_API_KEY for backward compatibility.
+# Get a free key (generous free tier) at https://twelvelabs.io
+TWELVELABS_API_KEY=
 
 # Default chat model id (OpenAI-compatible).
 # - Used by the generic /ai_chat endpoint (if you use it) and as a fallback default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 Added an opt-in TwelveLabs Marengo backend for prompt-text embeddings used by topic clustering and semantic search.
 
 - Set `EMBEDDING_MODEL=marengo3.0` to route embeddings through TwelveLabs Marengo instead of an OpenAI-compatible endpoint.
-- `OPENAI_API_KEY` is reused as the TwelveLabs API key; `OPENAI_BASE_URL` is ignored for embeddings.
+- Set `TWELVELABS_API_KEY` to your TwelveLabs key (falls back to `OPENAI_API_KEY` if unset, for backward compatibility); `OPENAI_BASE_URL` is ignored for embeddings.
 - Fully opt-in and non-breaking: the default OpenAI-compatible path is unchanged unless a Marengo model is selected.
 - Requires the optional dependency `twelvelabs>=1.2.8`. Free API key at https://twelvelabs.io .
 
@@ -836,7 +836,7 @@ Triggered under the same circumstances as above, there will be a button to updat
 为主题聚类与语义搜索所用的提示词文本向量，新增可选的 TwelveLabs Marengo 后端。
 
 - 设置 `EMBEDDING_MODEL=marengo3.0`，即可将向量计算改为走 TwelveLabs Marengo，而非 OpenAI 兼容接口。
-- 此时 `OPENAI_API_KEY` 复用为 TwelveLabs API Key；向量计算会忽略 `OPENAI_BASE_URL`。
+- 设置 `TWELVELABS_API_KEY` 为你的 TwelveLabs Key（未设置时回退到 `OPENAI_API_KEY`，以保持向后兼容）；向量计算会忽略 `OPENAI_BASE_URL`。
 - 完全可选且不影响现有行为：未选择 Marengo 模型时，默认的 OpenAI 兼容路径保持不变。
 - 需要可选依赖 `twelvelabs>=1.2.8`。可在 https://twelvelabs.io 获取免费 API Key。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 [跳到中文](#中文)
 # English
 
+## 2026-06-23
+### 🔎 Optional TwelveLabs Marengo embedding backend
+Added an opt-in TwelveLabs Marengo backend for prompt-text embeddings used by topic clustering and semantic search.
+
+- Set `EMBEDDING_MODEL=marengo3.0` to route embeddings through TwelveLabs Marengo instead of an OpenAI-compatible endpoint.
+- `OPENAI_API_KEY` is reused as the TwelveLabs API key; `OPENAI_BASE_URL` is ignored for embeddings.
+- Fully opt-in and non-breaking: the default OpenAI-compatible path is unchanged unless a Marengo model is selected.
+- Requires the optional dependency `twelvelabs>=1.2.8`. Free API key at https://twelvelabs.io .
+
 ## 2026-05-17
 ### 📊 Trend & Statistics Panel
 Added a new Trend & Statistics panel providing a visual overview of your image generation activity over time.
@@ -821,6 +830,15 @@ Triggered under the same circumstances as above, there will be a button to updat
 
 
 # 中文
+
+## 2026-06-23
+### 🔎 可选的 TwelveLabs Marengo 向量后端
+为主题聚类与语义搜索所用的提示词文本向量，新增可选的 TwelveLabs Marengo 后端。
+
+- 设置 `EMBEDDING_MODEL=marengo3.0`，即可将向量计算改为走 TwelveLabs Marengo，而非 OpenAI 兼容接口。
+- 此时 `OPENAI_API_KEY` 复用为 TwelveLabs API Key；向量计算会忽略 `OPENAI_BASE_URL`。
+- 完全可选且不影响现有行为：未选择 Marengo 模型时，默认的 OpenAI 兼容路径保持不变。
+- 需要可选依赖 `twelvelabs>=1.2.8`。可在 https://twelvelabs.io 获取免费 API Key。
 
 ## 2026-05-17
 ### 📊 趋势与统计面板

--- a/README.md
+++ b/README.md
@@ -308,8 +308,9 @@ alternative you can embed prompt text with [TwelveLabs](https://twelvelabs.io) M
 which embeds text/image/audio/video into one shared latent space:
 
 - Set **`EMBEDDING_MODEL=marengo3.0`**.
-- `OPENAI_API_KEY` is then used as your TwelveLabs API key; `OPENAI_BASE_URL` is ignored
-  for embeddings (the OpenAI-compatible chat path for cluster titles is unaffected).
+- Set **`TWELVELABS_API_KEY`** to your TwelveLabs key (falls back to `OPENAI_API_KEY` if
+  unset, for backward compatibility). `OPENAI_BASE_URL` is ignored for embeddings, and the
+  OpenAI-compatible chat path used for cluster titles is unaffected.
 - Install the optional dependency: `pip install 'twelvelabs>=1.2.8'`.
 
 This is fully opt-in and non-breaking — the default OpenAI-compatible path is unchanged

--- a/README.md
+++ b/README.md
@@ -295,10 +295,25 @@ All calls use an **OpenAI-compatible** provider:
 
 - **`OPENAI_BASE_URL`**: e.g. `https://your-host/v1`
 - **`OPENAI_API_KEY`**: your API key
-- **`EMBEDDING_MODEL`**: embeddings model used for clustering
+- **`EMBEDDING_MODEL`**: embeddings model used for clustering and semantic search
 - **`AI_MODEL`**: default chat model (fallback)
 - **`TOPIC_TITLE_MODEL`**: chat model used for cluster titles (falls back to `AI_MODEL`)
 - **`IIB_PROMPT_NORMALIZE`**: `1/0` enable prompt normalization
 - **`IIB_PROMPT_NORMALIZE_MODE`**: `balanced` (recommended) / `theme_only`
+
+##### Optional: TwelveLabs Marengo embedding backend
+
+Embeddings normally go to an OpenAI-compatible `/embeddings` endpoint. As an opt-in
+alternative you can embed prompt text with [TwelveLabs](https://twelvelabs.io) Marengo,
+which embeds text/image/audio/video into one shared latent space:
+
+- Set **`EMBEDDING_MODEL=marengo3.0`**.
+- `OPENAI_API_KEY` is then used as your TwelveLabs API key; `OPENAI_BASE_URL` is ignored
+  for embeddings (the OpenAI-compatible chat path for cluster titles is unaffected).
+- Install the optional dependency: `pip install 'twelvelabs>=1.2.8'`.
+
+This is fully opt-in and non-breaking — the default OpenAI-compatible path is unchanged
+unless you select a Marengo model. You can grab a free API key (generous free tier) at
+<https://twelvelabs.io>.
 
 > Note: There is **no mock fallback** for AI calls. If the provider/model fails or returns invalid output, the API will return an error directly.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ filetype
 requests>=2.0.0,<3.0.0
 numpy>=1.10.0,<3.0.0
 hnswlib>=0.0.0,<1.0.0
+# Optional: TwelveLabs Marengo embedding backend (set EMBEDDING_MODEL=marengo3.0).
+# Only needed if you opt in; the default OpenAI-compatible path does not require it.
+# twelvelabs>=1.2.8

--- a/scripts/iib/api.py
+++ b/scripts/iib/api.py
@@ -102,10 +102,22 @@ OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
 AI_MODEL = os.getenv("AI_MODEL", "gpt-4o-mini")
 EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
 
+# Dedicated TwelveLabs key for the optional Marengo embedding backend, kept
+# separate from OPENAI_API_KEY so the OpenAI-compatible chat path (cluster
+# titles) and the Marengo embedding path can use different services without
+# clobbering each other. Falls back to the SDK's own var and then to
+# OPENAI_API_KEY for backward compatibility.
+TWELVELABS_API_KEY = (
+    os.getenv("TWELVELABS_API_KEY")
+    or os.getenv("TWELVE_LABS_API_KEY")
+    or OPENAI_API_KEY
+)
+
 print(f"AI Model: {AI_MODEL or 'Not configured'}")
 print(f"OpenAI Base URL: {OPENAI_BASE_URL}")
 print(f"OpenAI API Key: {'Configured' if OPENAI_API_KEY else 'Not configured'}")
 print(f"Embedding Model: {EMBEDDING_MODEL or 'Not configured'}")
+print(f"TwelveLabs API Key: {'Configured' if TWELVELABS_API_KEY else 'Not configured'}")
 
 WRITEABLE_PERMISSIONS = ["read-write", "write-only"]
 
@@ -1486,6 +1498,7 @@ def infinite_image_browsing_api(app: FastAPI, **kwargs):
         write_permission_required=write_permission_required,
         openai_base_url=OPENAI_BASE_URL,
         openai_api_key=OPENAI_API_KEY,
+        twelvelabs_api_key=TWELVELABS_API_KEY,
         embedding_model=EMBEDDING_MODEL,
         ai_model=AI_MODEL,
     )

--- a/scripts/iib/marengo_embedding.py
+++ b/scripts/iib/marengo_embedding.py
@@ -52,7 +52,7 @@ def marengo_text_embeddings(
     if not api_key:
         raise HTTPException(
             status_code=500,
-            detail="TwelveLabs API key not configured (set OPENAI_API_KEY)",
+            detail="TwelveLabs API key not configured (set TWELVELABS_API_KEY)",
         )
 
     try:

--- a/scripts/iib/marengo_embedding.py
+++ b/scripts/iib/marengo_embedding.py
@@ -1,0 +1,92 @@
+"""
+Optional TwelveLabs Marengo embedding backend.
+
+The topic-cluster / semantic-search feature normally talks to an
+OpenAI-compatible ``/embeddings`` endpoint. Marengo is *not* OpenAI-compatible
+(different request/response shape), so when the user opts in by setting
+``EMBEDDING_MODEL`` to a Marengo model name (e.g. ``marengo3.0``) we route text
+embedding through the TwelveLabs SDK instead.
+
+This is fully opt-in: if ``EMBEDDING_MODEL`` is not a Marengo model, nothing in
+this module runs and the existing OpenAI-compatible path is used unchanged.
+
+Marengo embeds text, image, audio and video into one shared 512-dim latent
+space, which makes it a natural fit for the project's existing cosine-similarity
+search over image prompts.
+
+Get a free API key (generous free tier) at https://twelvelabs.io .
+"""
+
+from typing import List, Optional
+
+from fastapi import HTTPException
+
+from scripts.iib.logger import logger
+
+# Default Marengo model. Older retrieval models (e.g. "Marengo-retrieval-2.7")
+# are rejected by the current embed endpoint; "marengo3.0" is the supported one.
+DEFAULT_MARENGO_MODEL = "marengo3.0"
+
+
+def is_marengo_model(model: Optional[str]) -> bool:
+    """True if the configured embedding model should be served by Marengo."""
+    return bool(model) and str(model).strip().lower().startswith("marengo")
+
+
+def marengo_text_embeddings(
+    *,
+    inputs: List[str],
+    model: str,
+    api_key: str,
+) -> List[List[float]]:
+    """
+    Create text embeddings via TwelveLabs Marengo.
+
+    Mirrors the contract of the OpenAI-compatible path in topic_cluster.py:
+    returns one float vector per input string, in input order.
+
+    The TwelveLabs embed endpoint takes a single ``text`` per call, so we issue
+    one call per input. Errors are surfaced as HTTPException to match the rest
+    of the embedding pipeline.
+    """
+    if not api_key:
+        raise HTTPException(
+            status_code=500,
+            detail="TwelveLabs API key not configured (set OPENAI_API_KEY)",
+        )
+
+    try:
+        from twelvelabs import TwelveLabs
+    except ImportError as e:
+        raise HTTPException(
+            status_code=500,
+            detail="twelvelabs SDK not installed. Run: pip install 'twelvelabs>=1.2.8'",
+        ) from e
+
+    client = TwelveLabs(api_key=api_key)
+    vectors: List[List[float]] = []
+    for text in inputs:
+        # Marengo rejects empty text; use a single space as a harmless placeholder
+        # so vector count stays aligned with the input list.
+        safe_text = text if (text and text.strip()) else " "
+        try:
+            res = client.embed.create(model_name=model, text=safe_text)
+        except Exception as e:  # SDK raises typed errors; normalize for the pipeline
+            logger.error("[marengo] embed.create failed: %s", str(e)[:300])
+            raise HTTPException(
+                status_code=502, detail=f"Marengo embedding failed: {e}"
+            ) from e
+
+        seg = getattr(getattr(res, "text_embedding", None), "segments", None)
+        if not seg or getattr(seg[0], "float_", None) is None:
+            raise HTTPException(
+                status_code=502, detail="Marengo returned no text embedding"
+            )
+        vectors.append([float(x) for x in seg[0].float_])
+
+    logger.info(
+        "[marengo] embedded %s input(s), dim=%s",
+        len(vectors),
+        len(vectors[0]) if vectors else 0,
+    )
+    return vectors

--- a/scripts/iib/marengo_embedding.py
+++ b/scripts/iib/marengo_embedding.py
@@ -27,6 +27,30 @@ from scripts.iib.logger import logger
 # are rejected by the current embed endpoint; "marengo3.0" is the supported one.
 DEFAULT_MARENGO_MODEL = "marengo3.0"
 
+# Marengo has a hard 500-token limit per text input. Use 450 to leave headroom
+# because we can only estimate tokens (4 ASCII chars ≈ 1 token, 1 CJK ≈ 1 token)
+# without access to Marengo's actual tokenizer.
+_MARENGO_MAX_TOKENS = 450
+
+
+def _truncate_to_token_budget(text: str, max_tokens: int = _MARENGO_MAX_TOKENS) -> str:
+    """Conservative token-aware truncation, same algorithm as topic_cluster."""
+    if not text or not text.strip():
+        return " "
+    tokens = 0
+    ascii_bucket = 0
+    for i, ch in enumerate(text):
+        if ord(ch) < 128:
+            ascii_bucket += 1
+            if ascii_bucket >= 4:
+                tokens += 1
+                ascii_bucket = 0
+        else:
+            tokens += 1
+        if tokens >= max_tokens:
+            return text[: i + 1].strip()
+    return text
+
 
 def is_marengo_model(model: Optional[str]) -> bool:
     """True if the configured embedding model should be served by Marengo."""
@@ -46,8 +70,9 @@ def marengo_text_embeddings(
     returns one float vector per input string, in input order.
 
     The TwelveLabs embed endpoint takes a single ``text`` per call, so we issue
-    one call per input. Errors are surfaced as HTTPException to match the rest
-    of the embedding pipeline.
+    one call per input. Per-item failures (SDK errors, empty results from content
+    filtering) return ``None`` for that item so a single bad prompt doesn't kill
+    the whole batch.
     """
     if not api_key:
         raise HTTPException(
@@ -64,29 +89,45 @@ def marengo_text_embeddings(
         ) from e
 
     client = TwelveLabs(api_key=api_key)
-    vectors: List[List[float]] = []
+    vectors: List[Optional[List[float]]] = []
     for text in inputs:
         # Marengo rejects empty text; use a single space as a harmless placeholder
         # so vector count stays aligned with the input list.
         safe_text = text if (text and text.strip()) else " "
+        # Pre-truncate to stay under Marengo's 500-token limit. The caller
+        # (topic_cluster) already truncates with a generous OpenAI budget,
+        # but Marengo is much stricter and uses its own tokenizer.
+        safe_text = _truncate_to_token_budget(safe_text)
         try:
             res = client.embed.create(model_name=model, text=safe_text)
-        except Exception as e:  # SDK raises typed errors; normalize for the pipeline
-            logger.error("[marengo] embed.create failed: %s", str(e)[:300])
-            raise HTTPException(
-                status_code=502, detail=f"Marengo embedding failed: {e}"
-            ) from e
+        except Exception as e:  # per-item failure: log, skip, don't kill the batch
+            logger.error("[marengo] embed.create failed for text len=%d: %s",
+                         len(safe_text), str(e)[:200])
+            vectors.append(None)
+            continue
 
         seg = getattr(getattr(res, "text_embedding", None), "segments", None)
         if not seg or getattr(seg[0], "float_", None) is None:
-            raise HTTPException(
-                status_code=502, detail="Marengo returned no text embedding"
+            # Marengo returns empty segments when the prompt exceeds the 500-token
+            # limit, or for certain content it refuses to embed. Include the
+            # error_message (e.g. "The text token length should be less than or
+            # equal to 500.") so the failure record is actionable.
+            err_msg = getattr(
+                getattr(res, "text_embedding", None), "error_message", None
+            ) or "empty embedding"
+            logger.warning(
+                "[marengo] empty embedding for text len=%d: %s",
+                len(safe_text), err_msg,
             )
+            vectors.append(None)
+            continue
         vectors.append([float(x) for x in seg[0].float_])
 
+    ok = sum(1 for v in vectors if v is not None)
     logger.info(
-        "[marengo] embedded %s input(s), dim=%s",
+        "[marengo] embedded %s/%s input(s), dim=%s",
+        ok,
         len(vectors),
-        len(vectors[0]) if vectors else 0,
+        len(vectors[0]) if ok else 0,
     )
     return vectors

--- a/scripts/iib/test_marengo_embedding.py
+++ b/scripts/iib/test_marengo_embedding.py
@@ -1,0 +1,109 @@
+"""
+Focused tests for the optional TwelveLabs Marengo embedding backend.
+
+Run from the repo root:
+
+    python -m unittest scripts.iib.test_marengo_embedding
+
+The live test hits the TwelveLabs API and is skipped unless
+TWELVELABS_API_KEY is set in the environment.
+"""
+
+import os
+import sys
+import types
+import unittest
+
+# Allow running from the repo root without installing the package.
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+
+from scripts.iib.marengo_embedding import is_marengo_model, marengo_text_embeddings
+
+
+class IsMarengoModelTest(unittest.TestCase):
+    def test_selects_marengo_models(self):
+        self.assertTrue(is_marengo_model("marengo3.0"))
+        self.assertTrue(is_marengo_model("Marengo3.0"))
+        self.assertTrue(is_marengo_model("  marengo-retrieval-2.7 "))
+
+    def test_ignores_other_models(self):
+        self.assertFalse(is_marengo_model("text-embedding-3-small"))
+        self.assertFalse(is_marengo_model("nomic-embed-text"))
+        self.assertFalse(is_marengo_model(""))
+        self.assertFalse(is_marengo_model(None))
+
+
+class MarengoTextEmbeddingsNoNetworkTest(unittest.TestCase):
+    """Verify request wiring and response parsing without hitting the network."""
+
+    def _install_fake_sdk(self, captured):
+        class _Seg:
+            float_ = [0.1, 0.2, 0.3]
+
+        class _TextEmbedding:
+            segments = [_Seg()]
+
+        class _Resp:
+            text_embedding = _TextEmbedding()
+
+        class _Embed:
+            def create(self, *, model_name, text):
+                captured.append((model_name, text))
+                return _Resp()
+
+        class _Client:
+            def __init__(self, api_key):
+                captured.append(("api_key_len", len(api_key)))
+                self.embed = _Embed()
+
+        fake = types.ModuleType("twelvelabs")
+        fake.TwelveLabs = _Client
+        sys.modules["twelvelabs"] = fake
+
+    def setUp(self):
+        self._saved = sys.modules.get("twelvelabs")
+
+    def tearDown(self):
+        if self._saved is not None:
+            sys.modules["twelvelabs"] = self._saved
+        else:
+            sys.modules.pop("twelvelabs", None)
+
+    def test_returns_one_vector_per_input(self):
+        captured = []
+        self._install_fake_sdk(captured)
+        out = marengo_text_embeddings(
+            inputs=["a cat", "a dog"], model="marengo3.0", api_key="secret"
+        )
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[0], [0.1, 0.2, 0.3])
+        # Both inputs forwarded with the configured model.
+        models = [m for (m, _t) in captured if m == "marengo3.0"]
+        self.assertEqual(len(models), 2)
+
+    def test_empty_input_replaced_with_placeholder(self):
+        captured = []
+        self._install_fake_sdk(captured)
+        marengo_text_embeddings(inputs=[""], model="marengo3.0", api_key="secret")
+        texts = [t for (m, t) in captured if m == "marengo3.0"]
+        self.assertEqual(texts, [" "])
+
+
+class MarengoTextEmbeddingsLiveTest(unittest.TestCase):
+    @unittest.skipUnless(
+        os.environ.get("TWELVELABS_API_KEY"), "TWELVELABS_API_KEY not set"
+    )
+    def test_real_embedding_has_expected_dim(self):
+        out = marengo_text_embeddings(
+            inputs=["a cat sitting on a sofa"],
+            model="marengo3.0",
+            api_key=os.environ["TWELVELABS_API_KEY"],
+        )
+        self.assertEqual(len(out), 1)
+        self.assertEqual(len(out[0]), 512)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/iib/topic_cluster.py
+++ b/scripts/iib/topic_cluster.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 from scripts.iib.db.datamodel import DataBase, ImageEmbedding, ImageEmbeddingFail, TopicClusterCache, TopicTitleCache
 from scripts.iib.tool import cwd, accumulate_streaming_response
 from scripts.iib.logger import logger
+from scripts.iib.marengo_embedding import is_marengo_model, marengo_text_embeddings
 
 # Perf deps (required for this feature)
 _np = None
@@ -429,6 +430,12 @@ def _call_embeddings_sync(
 ) -> List[List[float]]:
     logger.info("[embeddings] === _call_embeddings_sync START ===")
     logger.info("[embeddings] base_url=%s model=%s n_inputs=%s", base_url, model, len(inputs))
+
+    # Opt-in TwelveLabs Marengo backend: selected purely by the embedding model
+    # name (e.g. EMBEDDING_MODEL=marengo3.0). Marengo is not OpenAI-compatible,
+    # so it has its own client; the OpenAI path below is untouched otherwise.
+    if is_marengo_model(model):
+        return marengo_text_embeddings(inputs=inputs, model=model, api_key=api_key)
 
     if not api_key:
         logger.error("[embeddings] API Key not configured")

--- a/scripts/iib/topic_cluster.py
+++ b/scripts/iib/topic_cluster.py
@@ -427,15 +427,19 @@ def _call_embeddings_sync(
     model: str,
     base_url: str,
     api_key: str,
+    tl_api_key: Optional[str] = None,
 ) -> List[List[float]]:
     logger.info("[embeddings] === _call_embeddings_sync START ===")
     logger.info("[embeddings] base_url=%s model=%s n_inputs=%s", base_url, model, len(inputs))
 
     # Opt-in TwelveLabs Marengo backend: selected purely by the embedding model
     # name (e.g. EMBEDDING_MODEL=marengo3.0). Marengo is not OpenAI-compatible,
-    # so it has its own client; the OpenAI path below is untouched otherwise.
+    # so it has its own dedicated key (TWELVELABS_API_KEY) and client; the
+    # OpenAI path below is untouched otherwise.
     if is_marengo_model(model):
-        return marengo_text_embeddings(inputs=inputs, model=model, api_key=api_key)
+        return marengo_text_embeddings(
+            inputs=inputs, model=model, api_key=tl_api_key or api_key
+        )
 
     if not api_key:
         logger.error("[embeddings] API Key not configured")
@@ -528,6 +532,7 @@ async def _call_embeddings(
     model: str,
     base_url: str,
     api_key: str,
+    tl_api_key: Optional[str] = None,
 ) -> List[List[float]]:
     """
     IMPORTANT:
@@ -540,6 +545,7 @@ async def _call_embeddings(
         model=model,
         base_url=base_url,
         api_key=api_key,
+        tl_api_key=tl_api_key,
     )
 
 
@@ -824,6 +830,7 @@ def mount_topic_cluster_routes(
     openai_api_key: str,
     embedding_model: str,
     ai_model: str,
+    twelvelabs_api_key: str = "",
 ):
     """
     Mount embedding + topic clustering endpoints (MVP: manual, iib_output only).
@@ -1011,13 +1018,18 @@ def mount_topic_cluster_routes(
         logger.info("[build_embeddings] folder=%s model=%s force=%s batch_size=%s max_chars=%s recursive=%s",
                     folder, model, force, batch_size, max_chars, recursive)
 
-        if not openai_api_key:
-            logger.error("[build_embeddings] OpenAI API Key not configured")
-            raise HTTPException(status_code=500, detail="OpenAI API Key not configured")
+        if is_marengo_model(model):
+            if not twelvelabs_api_key:
+                logger.error("[build_embeddings] TwelveLabs API Key not configured")
+                raise HTTPException(status_code=500, detail="TwelveLabs API Key not configured")
+        else:
+            if not openai_api_key:
+                logger.error("[build_embeddings] OpenAI API Key not configured")
+                raise HTTPException(status_code=500, detail="OpenAI API Key not configured")
 
-        if not openai_base_url:
-            logger.error("[build_embeddings] OpenAI Base URL not configured")
-            raise HTTPException(status_code=500, detail="OpenAI Base URL not configured")
+            if not openai_base_url:
+                logger.error("[build_embeddings] OpenAI Base URL not configured")
+                raise HTTPException(status_code=500, detail="OpenAI Base URL not configured")
 
         logger.info("[build_embeddings] Configuration check passed")
         logger.info("[build_embeddings] API URL: %s", openai_base_url)
@@ -1142,6 +1154,7 @@ def mount_topic_cluster_routes(
                     model=model,
                     base_url=openai_base_url,
                     api_key=openai_api_key,
+                    tl_api_key=twelvelabs_api_key,
                 )
                 logger.info("[build_embeddings] Embedding API success for batch %d/%d",
                           bi+1, len(batches))
@@ -1248,12 +1261,16 @@ def mount_topic_cluster_routes(
     async def build_iib_output_embeddings(req: BuildIibOutputEmbeddingReq):
         # TopicSearch feature requires perf deps; fail at API layer, not at server start.
         _ensure_perf_deps()
-        if not openai_api_key:
-            raise HTTPException(status_code=500, detail="OpenAI API Key not configured")
-        if not openai_base_url:
-            raise HTTPException(status_code=500, detail="OpenAI Base URL not configured")
         folder = req.folder or os.path.join(cwd, "iib_output")
         model = req.model or embedding_model
+        if is_marengo_model(model):
+            if not twelvelabs_api_key:
+                raise HTTPException(status_code=500, detail="TwelveLabs API Key not configured")
+        else:
+            if not openai_api_key:
+                raise HTTPException(status_code=500, detail="OpenAI API Key not configured")
+            if not openai_base_url:
+                raise HTTPException(status_code=500, detail="OpenAI Base URL not configured")
         batch_size = max(1, min(int(req.batch_size or 64), 256))
         max_chars = max(256, min(int(req.max_chars or 4000), 8000))
         force = bool(req.force)
@@ -1840,10 +1857,14 @@ def mount_topic_cluster_routes(
     async def search_iib_output_by_prompt(req: PromptSearchReq):
         # TopicSearch feature requires perf deps; fail at API layer, not at server start.
         _ensure_perf_deps()
-        if not openai_api_key:
-            raise HTTPException(status_code=500, detail="OpenAI API Key not configured")
-        if not openai_base_url:
-            raise HTTPException(status_code=500, detail="OpenAI Base URL not configured")
+        if is_marengo_model(req.model or embedding_model):
+            if not twelvelabs_api_key:
+                raise HTTPException(status_code=500, detail="TwelveLabs API Key not configured")
+        else:
+            if not openai_api_key:
+                raise HTTPException(status_code=500, detail="OpenAI API Key not configured")
+            if not openai_base_url:
+                raise HTTPException(status_code=500, detail="OpenAI Base URL not configured")
 
         q = (req.query or "").strip()
         if not q:
@@ -1886,7 +1907,7 @@ def mount_topic_cluster_routes(
             if q_text2:
                 q_text = q_text2
         q_text = _truncate_for_embedding_tokens(q_text, _EMBEDDING_MAX_TOKENS_SOFT)
-        vecs = await _call_embeddings(inputs=[q_text], model=model, base_url=openai_base_url, api_key=openai_api_key)
+        vecs = await _call_embeddings(inputs=[q_text], model=model, base_url=openai_base_url, api_key=openai_api_key, tl_api_key=twelvelabs_api_key)
         if not vecs or not isinstance(vecs[0], list) or not vecs[0]:
             raise HTTPException(status_code=502, detail="Embedding API returned empty vector")
         qv = array("f", [float(x) for x in vecs[0]])

--- a/scripts/iib/topic_cluster.py
+++ b/scripts/iib/topic_cluster.py
@@ -1201,6 +1201,22 @@ def mount_topic_cluster_routes(
             if len(vectors) != len(batch):
                 raise HTTPException(status_code=500, detail="Embeddings count mismatch")
             for item, vec in zip(batch, vectors):
+                if vec is None:
+                    # Marengo content filter: single prompt was rejected but the
+                    # rest of the batch is fine. Record as a per-item failure.
+                    try:
+                        ImageEmbeddingFail.upsert(
+                            conn,
+                            image_id=int(item["id"]),
+                            model=str(model),
+                            text_hash=str(item.get("text_hash") or ""),
+                            error="Marengo returned empty embedding (token limit exceeded or content filtered)",
+                        )
+                    except Exception:
+                        pass
+                    failed += 1
+                    embedded_done += 1
+                    continue
                 ImageEmbedding.upsert(
                     conn=conn,
                     image_id=item["id"],


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

### What this adds
An **opt-in** [TwelveLabs](https://twelvelabs.io) Marengo backend for the prompt-text embeddings that power the existing **topic clustering** and **semantic search** features. When `EMBEDDING_MODEL` is set to a Marengo model (e.g. `marengo3.0`), embeddings are computed via the TwelveLabs SDK instead of the OpenAI-compatible `/embeddings` endpoint.

- New module `scripts/iib/marengo_embedding.py` (`is_marengo_model`, `marengo_text_embeddings`).
- Single dispatch point added at the top of `_call_embeddings_sync` in `scripts/iib/topic_cluster.py` — the one chokepoint both the embedding-build and the search-query paths already flow through, so clustering and natural-language search both work with no other changes.
- `OPENAI_API_KEY` is reused as the TwelveLabs API key; `OPENAI_BASE_URL` is ignored for embeddings (the chat path used for cluster titles is untouched).

### Why it helps
Marengo embeds text, image, audio and video into one shared latent space, which fits this project's existing cosine-similarity search over image prompts and gives users another high-quality embedding option alongside OpenAI-compatible providers and local Ollama.

### Opt-in / non-breaking
Nothing changes unless you select a Marengo model. The default `text-embedding-3-small` / OpenAI-compatible path is byte-for-byte unchanged. The dependency is listed as optional (commented in `requirements.txt`) and only imported when a Marengo model is selected.

### How it was tested
- `python -m unittest scripts.iib.test_marengo_embedding` — 5 tests pass:
  - no-network unit tests for model selection and request/response wiring (SDK stubbed),
  - a live test (skipped unless `TWELVELABS_API_KEY` is set) confirming a real `marengo3.0` text embedding returns a 512-dim vector.
- Verified `scripts/iib/topic_cluster.py` still imports cleanly with the new dispatch.
- Formatted new files with `black` (the repo's configured Python formatter).

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.