### PR TITLE
fix(db): use composite (date, id) cursor so tied timestamps aren't skipped

### DIFF
--- a/scripts/iib/db/datamodel.py
+++ b/scripts/iib/db/datamodel.py
@@ -37,6 +37,34 @@ class Cursor:
         self.next = next
 
 
+def make_page_cursor(date, image_id) -> str:
+    """Build the cursor for the next page from the last row of this page.
+
+    image.date is not unique (a bulk scan stamps hundreds of images with the
+    same second), so the id is carried along as a tiebreaker.
+    """
+    return "{}|{}".format(date, image_id)
+
+
+def page_cursor_clause(cursor: str, params: List, table="image"):
+    """WHERE fragment continuing after `cursor`, appending its params.
+
+    Returns None when there is no cursor. Cursors written by older versions
+    were a bare date; those still work, minus the tiebreaker.
+    """
+    if not cursor:
+        return None
+    date, sep, image_id = cursor.rpartition("|")
+    if sep:
+        try:
+            params.extend((date, date, int(image_id)))
+            return "({t}.date < ? OR ({t}.date = ? AND {t}.id < ?))".format(t=table)
+        except ValueError:
+            pass
+    params.append(cursor)
+    return "({}.date < ?)".format(table)
+
+
 class DataBase:
     local = threading.local()
 
@@ -283,9 +311,9 @@ class Image:
                 else:
                     where_clauses.append("(path LIKE ? OR exif LIKE ?)")
                     params.extend((f"%{substring}%", f"%{substring}%"))
-            if cursor:
-                where_clauses.append("(date < ?)")
-                params.append(cursor)
+            cursor_clause = page_cursor_clause(cursor, params)
+            if cursor_clause:
+                where_clauses.append(cursor_clause)
             if folder_paths:
                 folder_clauses = []
                 for folder_path in folder_paths:
@@ -309,7 +337,7 @@ class Image:
             if where_clauses:
                 sql += " WHERE "
                 sql += " AND ".join(where_clauses)
-            sql += " ORDER BY date DESC LIMIT ? "
+            sql += " ORDER BY image.date DESC, image.id DESC LIMIT ? "
             params.append(limit)
             cur.execute(sql, params)
             rows = cur.fetchall()
@@ -324,8 +352,11 @@ class Image:
             else:
                 deleted_ids.append(img.id)
         cls.safe_batch_remove(conn, deleted_ids)
-        if images:
-            api_cur.next = str(images[-1].date)
+        if rows:
+            # Advance past the last row read, not the last row kept: a trailing
+            # run of deleted files would otherwise rewind the cursor.
+            last = cls.from_row(rows[-1])
+            api_cur.next = make_page_cursor(last.date, last.id)
         return images, api_cur
     
     @classmethod
@@ -1021,9 +1052,10 @@ class ImageTag:
                 print(folder_path)
             where_clauses.append("(" + " OR ".join(folder_clauses) + ")")
 
-        if cursor and not random_sort:
-            where_clauses.append("(image.date < ?)")
-            params.append(cursor)
+        if not random_sort:
+            cursor_clause = page_cursor_clause(cursor, params)
+            if cursor_clause:
+                where_clauses.append(cursor_clause)
         if where_clauses:
             query += " WHERE " + " AND ".join(where_clauses)
         query += " GROUP BY image.id"
@@ -1041,7 +1073,7 @@ class ImageTag:
                 except (ValueError, TypeError):
                     pass  # Invalid cursor, start from beginning
         else:
-            query += " ORDER BY date DESC LIMIT ?"
+            query += " ORDER BY image.date DESC, image.id DESC LIMIT ?"
         params.append(limit)
         api_cur = Cursor()
         with closing(conn.cursor()) as cur:
@@ -1057,14 +1089,15 @@ class ImageTag:
                     deleted_ids.append(img.id)
             Image.safe_batch_remove(conn, deleted_ids)
             api_cur.has_next = len(rows) >= limit
-            if images:
-                if random_sort:
+            if random_sort:
+                if images:
                     # For random sort, use offset-based cursor
                     current_offset = int(cursor) if cursor else 0
                     api_cur.next = str(current_offset + len(images))
-                else:
-                    # For date sort, use date-based cursor
-                    api_cur.next = str(images[-1].date)
+            elif rows:
+                # Advance past the last row read, not the last row kept: a
+                # trailing run of deleted files would otherwise rewind.
+                api_cur.next = make_page_cursor(rows[-1][3], rows[-1][0])
             return images, api_cur
 
     @classmethod


### PR DESCRIPTION
Fix for https://github.com/zanllp/infinite-image-browsing/issues/964

Fixes search pagination silently dropping results when many images share one `date`. This occurs often when images are bulk downloaded from civitai or remote servers such as runpod.

`image.date` is not unique — bulk scans stamp hundreds of images with the same second — but both search paths paginate on `date` alone with a strict `<`. A page boundary landing inside a tie group discards every remaining row with that timestamp. On my library, tag `asuka langley soryu` returned 452 of 578 matches, and the missing 126 were unreachable at any scroll depth.

### Changes — `scripts/iib/db/datamodel.py`

Two helpers next to `Cursor`:

- `make_page_cursor(date, id)` → `"<date>|<id>"`
- `page_cursor_clause(cursor, params, table)` → `(t.date < ? OR (t.date = ? AND t.id < ?))`

Applied to `find_by_substring` and `get_images_by_tags`, both now ordering by `date DESC, id DESC`.

Also: the cursor now advances past the last row *read* rather than the last row *kept*, so a page ending in a run of deleted files no longer rewinds and re-serves rows.

`random_sort` is untouched — it uses integer offsets and was never affected.

### Compatibility

Cursors written by an older version are a bare date. Those still parse and fall back to the previous `date < ?` clause, so a page already open in a browser won't error mid-scroll. The cursor is opaque to the frontend (`vue/src/api/db.ts` passes `next` straight back), so no client change is needed.

### Verification

Against a real 18k-image DB:

```
tag search    → 578 rows, 578 unique, 3 pages   (was 452)
substr search → 579 rows, 579 unique, 3 pages
legacy cursor → accepted, emits 2025-08-16 21:20:57|2253
random_sort   → unchanged
```

No duplicates across pages; the previously missing images are all present.

*written by Claude Opus 5