### PR TITLE
Fix path traversal in is_path_trusted (CWE-22/CWE-59)

### DIFF
--- a/scripts/iib/api.py
+++ b/scripts/iib/api.py
@@ -333,11 +333,12 @@ def infinite_image_browsing_api(app: FastAPI, **kwargs):
             parent_paths = mem["all_scanned_paths"]
             path = to_abs_path(path)
             for parent_path in parent_paths:
+                parent_path = os.path.realpath(parent_path)
                 if len(path) <= len(parent_path):
                     if parent_path.startswith(path):
                         return True
                 else:
-                    if path.startswith(parent_path):
+                    if path.startswith(parent_path + os.sep):
                         return True
         except:
             pass

--- a/scripts/iib/tool.py
+++ b/scripts/iib/tool.py
@@ -172,7 +172,7 @@ def normalize_paths(paths: List[str], base = cwd):
 def to_abs_path(path):
     if not os.path.isabs(path):
         path = os.path.join(os.getcwd(), path)
-    return os.path.normpath(path)
+    return os.path.realpath(path)
 
 
 def get_valid_img_dirs(


### PR DESCRIPTION
Use os.path.realpath() instead of normpath to resolve symlinks, and add trailing os.sep to startswith() to prevent prefix collision.
fix #968 